### PR TITLE
Adding support for use with Go modules

### DIFF
--- a/fixtures.go
+++ b/fixtures.go
@@ -328,6 +328,14 @@ func Init() error {
 		}
 	}
 
+	// Try the modules local cache
+	if dir, err := os.Getwd(); err == nil {
+		if pkg, err := build.Default.Import("gopkg.in/src-d/go-git-fixtures.v3", dir, build.FindOnly); err == nil {
+			RootFolder = pkg.Dir
+			return nil
+		}
+	}
+
 	return errors.New("fixtures folder not found")
 }
 


### PR DESCRIPTION
Previous to this patch if you try to run the test of go-git in a Go
modules environment, the tests fail due to go-git-fixtures package is
not found. In order to found the package on this environment, the
build.Context.Import function is leveraged.

Signed-off-by: Pablo Andres Fuente <pablo.andres.fuente@gmail.com>